### PR TITLE
[main] Add CI workflow for build and test automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main, ci-setup ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+    - name: Test
+      run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main, ci-setup ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
This pull request sets up a new GitHub Actions workflow for automated building and testing of the project using .NET. The workflow ensures that code is built and tested on every push and pull request to the main branch, helping maintain code quality and catch issues early.

Continuous integration setup:

* Added `.github/workflows/ci.yml` to configure a CI pipeline that runs on pushes and pull requests to the `main` branch and the `ci-setup` branch.
* Configured the workflow to use Ubuntu runners, check out the code, set up .NET 8, restore dependencies, build the project in Release mode, and run tests with code coverage collection.